### PR TITLE
gui: drop deprecated groups

### DIFF
--- a/gui/GameConqueror.desktop
+++ b/gui/GameConqueror.desktop
@@ -6,5 +6,5 @@ Exec=gameconqueror
 Terminal=false
 Type=Application
 Icon=GameConqueror
-Categories=GNOME;Application;Game;
+Categories=Game;
 StartupNotify=true


### PR DESCRIPTION
$ desktop-file-validate gui/GameConqueror.desktop
gui/GameConqueror.desktop: hint: value item "GNOME" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: GTK
gui/GameConqueror.desktop: warning: value "GNOME;Application;Game;" for key "Categories" in group "Desktop Entry" contains a deprecated value "Application"

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
