### PR TITLE
Use self.show_errors always

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -699,6 +699,7 @@ class GameConqueror():
             self.read_maps()
         except:
             self.show_error(_('Cannot retieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
+            return
         selected_region = None
         if addr:
             for m in self.maps:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/share/gameconqueror/GameConqueror.py", line 558, in cheatlist_popup_cb
    self.browse_memory(int(addr,16))
  File "/usr/share/gameconqueror/GameConqueror.py", line 705, in browse_memory
    show_error(_('Cannot retieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
NameError: global name 'show_error' is not defined

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
