### PR TITLE
maps/handlers: show offset in exe when setting a value

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -232,14 +232,18 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                         value_t v;
                         value_t old;
                         void *address = remote_address_of_nth_element(loc.swath, loc.index /* ,MATCHES_AND_VALUES */);
+                        char off_info[48] = { 0 };
 
                         /* copy val onto v */
                         /* XXX: valcmp? make sure the sizes match */
                         old = data_to_val(loc.swath, loc.index /* ,MATCHES_AND_VALUES */);
                         v.flags = old.flags = loc.swath->data[loc.index].match_info;
                         uservalue2value(&v, &userval);
-                        
-                        show_info("setting *%p to %#"PRIx64"...\n", address, v.int64_value); 
+
+                        if ((unsigned long)address >= exe_start && (unsigned long)address <= exe_end)
+                            snprintf(off_info, sizeof(off_info), "(exe %p) ",
+                                (void *)((unsigned long)address - exe_start));
+                        show_info("setting *%p %sto %#"PRIx64"...\n", address, off_info, v.int64_value);
 
                         /* set the value specified */
                         if (setaddr(vars->target, address, &v) == false) {
@@ -265,6 +269,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                     if (flags_to_max_width_in_bytes(reading_swath_index->data[reading_iterator].match_info) > 0)
                     {
                         void *address = remote_address_of_nth_element(reading_swath_index, reading_iterator /* ,MATCHES_AND_VALUES */);
+                        char off_info[48] = { 0 };
 
                         /* XXX: as above : make sure the sizes match */
                                     
@@ -273,7 +278,10 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                         v.flags = old.flags = reading_swath_index->data[reading_iterator].match_info;
                         uservalue2value(&v, &userval);
 
-                        show_info("setting *%p to %"PRIx64"...\n", address, v.int64_value); 
+                        if ((unsigned long)address >= exe_start && (unsigned long)address <= exe_end)
+                            snprintf(off_info, sizeof(off_info), "(exe %p) ",
+                                (void *)((unsigned long)address - exe_start));
+                        show_info("setting *%p %sto %"PRIx64"...\n", address, off_info, v.int64_value);
 
                         if (setaddr(vars->target, address, &v) == false) {
                             show_error("failed to set a value.\n");

--- a/maps.h
+++ b/maps.h
@@ -47,6 +47,9 @@ typedef struct {
     char filename[1];           /* associated file, must be last */
 } region_t;
 
+extern unsigned long exe_start;
+extern unsigned long exe_end;
+
 bool readmaps(pid_t target, list_t * regions);
 int compare_region_id(const region_t *a, const region_t *b);
 


### PR DESCRIPTION
We detect the regions belonging to the executable and determine
the start and the end address of the executable. With that
information we can detect static memory. Especially with a PIE
(position independent executable) and ASLR, it would be useful to
see the offset within the executable as the found memory address
is at a different memory location each execution. So show that
offset additionally when setting a static memory value.

Changes compared to v2:
- sizeof(off_info) made a power of 2
- "(in exe %p) " changed into "(exe %p) "

It is also imaginable to show the offset within the heap and the stack region later on to help with ASLR bypassing.
