### PR TITLE
maps/handlers: show offset in exe when setting a value

### DIFF
--- a/maps.c
+++ b/maps.c
@@ -40,15 +40,16 @@
 #include "scanmem.h"
 #include "show_message.h"
 
-bool readmaps(pid_t target, list_t * regions)
+bool readmaps(pid_t target, list_t *regions, struct mem_region *exe)
 {
     FILE *maps;
     char name[128], *line = NULL;
-    char exename[128];
+    char exelink[128];
     size_t len = 0;
+    bool exe_end_found = false;
 
 #define MAX_LINKBUF_SIZE 256
-    char linkbuf[MAX_LINKBUF_SIZE];
+    char linkbuf[MAX_LINKBUF_SIZE], *exename = linkbuf;
     int linkbuf_size;
 
     /* check if target is valid */
@@ -65,6 +66,23 @@ bool readmaps(pid_t target, list_t * regions)
         }
 
         show_info("maps file located at %s opened.\n", name);
+
+        /* get executable name */
+        snprintf(exelink, sizeof(exelink), "/proc/%u/exe", target);
+        if ((linkbuf_size = readlink(exelink, exename, MAX_LINKBUF_SIZE)) > 0)
+        {
+            exename[linkbuf_size] = 0;
+            exe->start = 0;
+            exe->end = 0;
+        } else {
+            /* readlink may fail for special processes, just treat as empty in
+               order not to miss those regions */
+            exename[0] = 0;
+            /* can't search for the executable regions */
+            exe->start = 1;
+            exe->end = 1;
+            exe_end_found = true;
+        }
 
         /* read every line of the maps file */
         while (getline(&line, &len, maps) != -1) {
@@ -85,6 +103,17 @@ bool readmaps(pid_t target, list_t * regions)
             /* parse each line */
             if (sscanf(line, "%lx-%lx %c%c%c%c %x %x:%x %u %s", &start, &end, &read,
                     &write, &exec, &cow, &offset, &dev_major, &dev_minor, &inode, filename) >= 6) {
+
+                /* get the executable start and end */
+                if (!exe->start) {
+                    if ((exec == 'x') && strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0)
+                        exe->start = start;
+                } else if (!exe_end_found) {
+                    if (filename[0] == '\0' || strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0)
+                        exe->end = end;
+                    else
+                        exe_end_found = true;
+                }
 
                 /* must have permissions to read and write, and be non-zero size */
                 if ((write == 'w') && (read == 'r') && ((end - start) > 0)) {
@@ -110,16 +139,7 @@ bool readmaps(pid_t target, list_t * regions)
                                 break;
                             }
                             /* test if the region is mapped to the executable */
-                            snprintf(exename, sizeof(exename), "/proc/%u/exe", target);
-                            if((linkbuf_size = readlink(exename, linkbuf, MAX_LINKBUF_SIZE)) > 0)
-                            {
-                                linkbuf[linkbuf_size] = 0;
-                            }
-                            else /* readlink may fail for special processes, just treat as empty in order not to miss those regions */
-                            {
-                                linkbuf[0] = 0;
-                            }
-                            if (strncmp(filename, linkbuf, MAX_LINKBUF_SIZE) == 0)
+                            if (strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0)
                                 useful = true;
                         break;
                 }

--- a/maps.h
+++ b/maps.h
@@ -47,7 +47,12 @@ typedef struct {
     char filename[1];           /* associated file, must be last */
 } region_t;
 
-bool readmaps(pid_t target, list_t * regions);
+struct mem_region {
+    unsigned long start;
+    unsigned long end;
+};
+
+bool readmaps(pid_t target, list_t *regions, struct mem_region *exe);
 int compare_region_id(const region_t *a, const region_t *b);
 
 #endif /* _MAPS_INC */

--- a/scanmem.c
+++ b/scanmem.c
@@ -46,6 +46,10 @@ globals_t globals = {
     NULL,                       /* matches */
     0,                          /* match count */
     0,                          /* scan progress */
+    {                           /* exe region */
+        0,                      /* start */
+        0,                      /* end */
+    },
     NULL,                       /* regions */
     NULL,                       /* commands */
     NULL,                       /* current_cmdline */

--- a/scanmem.h
+++ b/scanmem.h
@@ -60,6 +60,7 @@ typedef struct {
     matches_and_old_values_array *matches;
     long num_matches;
     double scan_progress;
+    struct mem_region exe;
     list_t *regions;
     list_t *commands;      /* command handlers */
     const char *current_cmdline; /* the command being executed */


### PR DESCRIPTION
Especially with a PIE (position independent executable) and ASLR,
it would be useful to see the offset within the executable as the
found static memory address is at a different memory location each
execution. So determine the start and the end address of the
executable in memory, calculate the offset and show it additionally
when setting the static memory value.

Changes compared to previous pull request:
- fixed the exe region check
- got rid of duplicate code by using inline helper functions
- got rid of global variables by extending globals_t
