### PR TITLE
gui: add semicolon as trailing to .desktop

### DIFF
--- a/gui/GameConqueror.desktop.in
+++ b/gui/GameConqueror.desktop.in
@@ -5,5 +5,5 @@ Exec=gameconqueror
 Terminal=false
 Type=Application
 Icon=GameConqueror
-Categories=Development;Utility
+Categories=Development;Utility;
 StartupNotify=true


### PR DESCRIPTION
```
/builddir/build/BUILDROOT/scanmem-0.14-3.de2653d.fc21.x86_64/usr/share/applications/GameConqueror.desktop: error: value "Development;Utility" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
