### PR TITLE
Configurable endianness of data

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ lib_LTLIBRARIES = libscanmem.la
 
 libscanmem_la_SOURCES = commands.h \
     commands.c \
+    endianness.c \
     ptrace.c \
     menu.c \
     handlers.h \

--- a/endianness.c
+++ b/endianness.c
@@ -1,0 +1,91 @@
+/*
+ $Id: $
+ 
+ Copyright (C) 2014           Hraban Luyat
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "endianness.h"
+#include "scanmem.h"
+#include "value.h"
+
+static uint16_t swap_bytes16(uint16_t i)
+{
+    uint16_t res = i & 0xff;
+    res <<= 8;
+    res |= i >> 8;
+    return res;
+}
+
+static uint32_t swap_bytes32(uint32_t i)
+{
+    uint32_t res = swap_bytes16(i);
+    res <<= 16;
+    res |= swap_bytes16(i >> 16);
+    return res;
+}
+
+static uint64_t swap_bytes64(uint64_t i)
+{
+    uint64_t res = swap_bytes32(i);
+    res <<= 32;
+    res |= swap_bytes32(i >> 32);
+    return res;
+}
+
+// swap endianness of 2, 4 or 8 byte word in-place.
+void swap_bytes_var(void *p, size_t num)
+{
+    switch (num) {
+    case sizeof(uint16_t): ; // empty statement to cheat the compiler
+        uint16_t i16 = swap_bytes16(*((uint16_t *)p));
+        memcpy(p, &i16, sizeof(uint16_t));
+        return;
+    case sizeof(uint32_t): ;
+        uint32_t i32 = swap_bytes32(*((uint32_t *)p));
+        memcpy(p, &i32, sizeof(uint32_t));
+        return;
+    case sizeof(uint64_t): ;
+        uint64_t i64 = swap_bytes64(*((uint64_t *)p));
+        memcpy(p, &i64, sizeof(uint64_t));
+        return;
+    }
+    assert(false);
+    return;
+}
+
+void fix_endianness(globals_t *vars, value_t *data_value)
+{
+    if (!vars->options.reverse_endianness) {
+        return;
+    }
+    if (data_value->flags.u64b) {
+        data_value->uint64_value = swap_bytes64(data_value->uint64_value);
+    } else if (data_value->flags.u32b) {
+        data_value->uint32_value = swap_bytes32(data_value->uint32_value);
+    } else if (data_value->flags.u16b) {
+        data_value->uint16_value = swap_bytes16(data_value->uint16_value);
+    }
+    return;
+}
+

--- a/endianness.h
+++ b/endianness.h
@@ -1,0 +1,36 @@
+/*
+ $Id: $
+
+ Copyright (C) 2014           Hraban Luyat
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+
+#ifndef _ENDIANNESS_INC
+#define _ENDIANNESS_INC
+
+#include "scanmem.h"
+#include "value.h"
+
+static const union { short x; char y; } endiantest = { .x = 0xabcd };
+// True iff host is big endian
+static const bool big_endian = endiantest.y == 0xab;
+
+void fix_endianness(globals_t *vars, value_t *data_value);
+void swap_bytes_var(void *p, size_t num);
+
+#endif
+

--- a/handlers.h
+++ b/handlers.h
@@ -297,6 +297,14 @@ bool handler__write(globals_t * vars, char **argv, unsigned argc);
                  "\t0:\tdisabled\n" \
                  "\t1:\tenabled\n" \
                  "\n" \
+                 "endianness\tendianness of data (used by: set, write and comparisons)\n" \
+                 "\t\t\tDefault:0\n" \
+                 "\n" \
+                 "\tpossible values:\n" \
+                 "\t0:\thost endian\n" \
+                 "\t1:\tlittle endian\n" \
+                 "\t2:\tbig endian\n" \
+                 "\n" \
                  "Example:\n" \
                  "\toption scan_data_type int32\n"
 

--- a/ptrace.c
+++ b/ptrace.c
@@ -59,6 +59,7 @@
 #endif
 
 #include "value.h"
+#include "endianness.h"
 #include "scanroutines.h"
 #include "scanmem.h"
 #include "show_message.h"
@@ -314,6 +315,8 @@ bool checkmatches(globals_t * vars,
             truncval_to_flags(&old_val, flags);
             truncval_to_flags(&data_value, flags);
 
+            fix_endianness(vars, &data_value);
+
             memset(&checkflags, 0, sizeof(checkflags));
 
             match_length = (*g_scan_routine)(&data_value, &old_val, uservalue, &checkflags, address);
@@ -551,6 +554,8 @@ bool searchregions(globals_t * vars, scan_match_type_t match_type, const userval
                 break;
             }
 #endif
+
+            fix_endianness(vars, &data_value);
 
             memset(&checkflags, 0, sizeof(checkflags));
 

--- a/scanmem.h
+++ b/scanmem.h
@@ -73,6 +73,7 @@ typedef struct {
         region_scan_level_t region_scan_level;
         unsigned short detect_reverse_change;
         unsigned short dump_with_ascii;
+        unsigned short reverse_endianness;
     } options;
 } globals_t;
 


### PR DESCRIPTION
Working on https://code.google.com/p/scanmem/issues/detail?id=70

This patch provides a runtime option, endianness. possible values:

0: data has same endianness as host
1: data is little endian
2: data is big endian

Commands that operate on words (set, write, and comparisons) respect
this setting when reading and writing.

Nothing is changed in the GUI, this is a command-line only option, for
now.

What do you think?
